### PR TITLE
Created SpecUtil class to handle the common api request config and common assertion.

### DIFF
--- a/src/test/java/com/api/tests/CountAPITest.java
+++ b/src/test/java/com/api/tests/CountAPITest.java
@@ -1,35 +1,31 @@
 package com.api.tests;
 
-import static org.hamcrest.Matchers.*;
+import static com.api.constant.Role.*;
+import static com.api.utils.ConfigManager.getProperty;
+import static io.restassured.RestAssured.given;
+import static io.restassured.module.jsv.JsonSchemaValidator.matchesJsonSchemaInClasspath;
+import static org.hamcrest.Matchers.blankOrNullString;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.everyItem;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
 
 import org.testng.annotations.Test;
 
-import static com.api.constant.Role.*;
-import static com.api.utils.AuthTokenProvider.*;
-
-import static io.restassured.module.jsv.JsonSchemaValidator.*;
-
-import static com.api.utils.ConfigManager.*;
-
-import static io.restassured.RestAssured.*;
+import com.api.utils.SpecUtil;
 
 public class CountAPITest {
 
 	@Test
 	public void countAPITest() {
 		given()
-		.baseUri(getProperty("BASE_URI"))
-		.and()
-		.header("Authorization",getToken(FD))
-		.log().uri()
-		.log().headers()
-		.log().method()
+		.spec(SpecUtil.requestSpecwithAuth(FD))
 		.when()
 		.get("dashboard/count")
 		.then()
-		.log().all()
-		.statusCode(200)
-		.time(lessThan(1000L))
+		.spec(SpecUtil.responseSpec_ok())
 		.body("message",equalTo("Success"))
 		.body(matchesJsonSchemaInClasspath("response_schema/CountAPIFDResponseSchema.json"))
 		.body("data",notNullValue())
@@ -42,14 +38,10 @@ public class CountAPITest {
 	@Test
 	public void countAPITest_missingAuthToken() {
 		given()
-		.baseUri(getProperty("BASE_URI"))
-		.log().uri()
-		.log().headers()
-		.log().method()
+		.spec(SpecUtil.requestSpec())
 		.when()
 		.get("dashboard/count")
 		.then()
-		.log().all()
-		.statusCode(401);
+		.spec(SpecUtil.responseSpec_TEXT(401));
 	}
 }

--- a/src/test/java/com/api/tests/LoginAPITest.java
+++ b/src/test/java/com/api/tests/LoginAPITest.java
@@ -1,17 +1,11 @@
 package com.api.tests;
 
-import static io.restassured.RestAssured.*;
-
-import static org.hamcrest.Matchers.*;
-
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
 import java.io.IOException;
-
 import org.testng.annotations.Test;
-
 import com.api.pojo.UserCredentials;
-import static com.api.utils.ConfigManager.*;
-
-import io.restassured.http.ContentType;
+import com.api.utils.SpecUtil;
 import io.restassured.module.jsv.JsonSchemaValidator;
 
 
@@ -20,23 +14,11 @@ public class LoginAPITest {
 	public void loginAPITest() throws IOException {
 		UserCredentials userCredentials = new UserCredentials("iamfd", "password");
     given()
-    	.baseUri(getProperty("BASE_URI"))
-    .and()
-        .contentType(ContentType.JSON)
-    .and()
-        .accept(ContentType.JSON)
-        .and()
-        .body(userCredentials)
-        .log().uri()
-        .log().headers()
-        .log().body()
-        .log().method()
+    	.spec(SpecUtil.requestSpec(userCredentials))
     .when()
      	.post("login")
     .then()
-    .log().all()
-    	.statusCode(200)
-    	.time(lessThan(2000L))
+    .spec(SpecUtil.responseSpec_ok())
         .and()
         .body("message", equalTo("Success"))
         .and()

--- a/src/test/java/com/api/tests/MasterAPITest.java
+++ b/src/test/java/com/api/tests/MasterAPITest.java
@@ -3,6 +3,8 @@ package com.api.tests;
 import static org.hamcrest.Matchers.*;
 import org.testng.annotations.Test;
 
+import com.api.utils.SpecUtil;
+
 import io.restassured.module.jsv.JsonSchemaValidator;
 
 import static com.api.constant.Role.*;
@@ -15,19 +17,11 @@ public class MasterAPITest {
 	@Test
 	public void masterAPITest() {
      given()
-     .baseUri(getProperty("BASE_URI"))
-     .header("Authorization",getToken(FD))
-     .and()
-     .contentType("")
+     .spec(SpecUtil.requestSpecwithAuth(FD))
      .when()
-     .log().uri()
-     .log().method()
-     .log().headers()
      .post("master")
      .then()
-     .log().all()
-     .statusCode(200)
-     .time(lessThan(1000L))
+     .spec(SpecUtil.responseSpec_ok())
      .body(JsonSchemaValidator.matchesJsonSchemaInClasspath("response_schema/MasterAPIResponseSchema_FD.json"))
      .body("message",equalToIgnoringCase("Success"))
      .body("data",notNullValue())
@@ -43,17 +37,10 @@ public class MasterAPITest {
 	@Test
 	public void invalidTokenMasterAPITest() {
 		given()
-	     .baseUri(getProperty("BASE_URI"))
-	     .header("Authorization","")
-	     .and()
-	     .contentType("")
+	     .spec(SpecUtil.requestSpec())
 	     .when()
-	     .log().uri()
-	     .log().method()
-	     .log().headers()
 	     .post("master")
 	     .then()
-	     .log().all()
-	     .statusCode(401);
+	     .spec(SpecUtil.responseSpec_TEXT(401));
 	}
 }

--- a/src/test/java/com/api/tests/UserDetailsAPITest.java
+++ b/src/test/java/com/api/tests/UserDetailsAPITest.java
@@ -1,38 +1,23 @@
 package com.api.tests;
 
-import static com.api.utils.AuthTokenProvider.getToken;
-import static com.api.utils.ConfigManager.getProperty;
+import static com.api.constant.Role.FD;
 import static io.restassured.RestAssured.given;
-import static org.hamcrest.Matchers.lessThan;
 
 import org.testng.annotations.Test;
 
-import static com.api.constant.Role.*;
+import com.api.utils.SpecUtil;
 
-import io.restassured.http.ContentType;
-import io.restassured.http.Header;
 import io.restassured.module.jsv.JsonSchemaValidator;
 
 public class UserDetailsAPITest {
 	@Test
 	public void userdetailsAPITest()  {
-		Header authHeader = new Header("Authorization",getToken(FD));
 		given()
-		.baseUri(getProperty("BASE_URI"))
-		.and()
-		.header(authHeader)
-		.and()
-		.contentType(ContentType.JSON)
-		.log().uri()
-		.log().method()
-		.log().headers()
-		.log().body()
+		.spec(SpecUtil.requestSpecwithAuth(FD))
 		.when()
 		.get("userdetails")
 		.then()
-		.log().all()
-		.statusCode(200)
-		.time(lessThan(2000L))
+		.spec(SpecUtil.responseSpec_ok())
 		.body(JsonSchemaValidator.matchesJsonSchemaInClasspath("response_schema/UserDetailsResponseSchema.json"));
 	}
 }

--- a/src/test/java/com/api/utils/SpecUtil.java
+++ b/src/test/java/com/api/utils/SpecUtil.java
@@ -1,0 +1,60 @@
+package com.api.utils;
+
+import static com.api.utils.ConfigManager.getProperty;
+
+import org.hamcrest.Matchers;
+
+import com.api.constant.Role;
+import com.api.pojo.UserCredentials;
+
+import io.restassured.builder.RequestSpecBuilder;
+import io.restassured.builder.ResponseSpecBuilder;
+import io.restassured.filter.log.LogDetail;
+import io.restassured.http.ContentType;
+import io.restassured.specification.RequestSpecification;
+import io.restassured.specification.ResponseSpecification;
+
+public class SpecUtil {
+
+	public static RequestSpecification requestSpec() {
+		RequestSpecification requestSpecification = new RequestSpecBuilder().setBaseUri(getProperty("BASE_URI"))
+				.setContentType(ContentType.JSON).setAccept(ContentType.JSON).log(LogDetail.URI).log(LogDetail.METHOD)
+				.log(LogDetail.HEADERS).log(LogDetail.BODY).build();
+
+		return requestSpecification;
+	}
+
+	public static RequestSpecification requestSpec(Object payload) {
+		RequestSpecification requestSpecification = new RequestSpecBuilder().setBaseUri(getProperty("BASE_URI"))
+				.setContentType(ContentType.JSON).setAccept(ContentType.JSON).setBody(payload)
+				.log(LogDetail.URI).log(LogDetail.METHOD).log(LogDetail.HEADERS).log(LogDetail.BODY).build();
+
+		return requestSpecification;
+	}
+
+	public static RequestSpecification requestSpecwithAuth(Role role) {
+		RequestSpecification requestSpecification = new RequestSpecBuilder().setBaseUri(getProperty("BASE_URI"))
+				.addHeader("Authorization", AuthTokenProvider.getToken(role)).setContentType(ContentType.JSON)
+				.setAccept(ContentType.JSON).log(LogDetail.URI).log(LogDetail.METHOD).log(LogDetail.HEADERS)
+				.log(LogDetail.BODY).build();
+		return requestSpecification;
+	}
+
+	public static ResponseSpecification responseSpec_ok() {
+		ResponseSpecification responseSpecification = new ResponseSpecBuilder().expectContentType(ContentType.JSON)
+				.expectStatusCode(200).expectResponseTime(Matchers.lessThan(1000L)).log(LogDetail.ALL).build();
+		return responseSpecification;
+	}
+	
+	public static ResponseSpecification responseSpec_JSON(int StatusCode) {
+		ResponseSpecification responseSpecification = new ResponseSpecBuilder().expectContentType(ContentType.JSON)
+				.expectStatusCode(StatusCode).expectResponseTime(Matchers.lessThan(1000L)).log(LogDetail.ALL).build();
+		return responseSpecification;
+	}
+	
+	public static ResponseSpecification responseSpec_TEXT(int StatusCode) {
+		ResponseSpecification responseSpecification = new ResponseSpecBuilder()
+				.expectStatusCode(StatusCode).expectResponseTime(Matchers.lessThan(1000L)).log(LogDetail.ALL).build();
+		return responseSpecification;
+	}
+}


### PR DESCRIPTION
SpecUtil class consist of RequestSpecBuilder and ReponseSpecBuilder. It is used to reduce boilerplate code and test code becomes smaller. 